### PR TITLE
Fixed small things

### DIFF
--- a/skills/src/creators/configuration/calculations/operations/built-in/get-attribute.md
+++ b/skills/src/creators/configuration/calculations/operations/built-in/get-attribute.md
@@ -3,8 +3,10 @@
 Converts [`minecraft:living_entity` prototype](/creators/configuration/calculations/prototypes/built-in/living-entity) into [`minecraft:entity_attribute_instance` prototype](/creators/configuration/calculations/prototypes/built-in/entity-attribute-instance) such that it represents the instance of given attribute. If the target has no attribute returns nothing.
 
 ### Properties
+
 #### Attribute
-Property `attribute` defines an [Attribute](https://minecraft.wiki/w/Attribute). This operation will get the attribute from the living entity.
+
+Property `attribute` defines an [Attribute](https://minecraft.wiki/w/Attribute). The operation will return [`minecraft:entity_attribute_instance`](/creators/configuration/calculations/prototypes/built-in/entity-attribute-instance) of this attribute from the living entity.
 
 # Examples
 

--- a/skills/src/creators/configuration/calculations/operations/built-in/get-attribute.md
+++ b/skills/src/creators/configuration/calculations/operations/built-in/get-attribute.md
@@ -2,6 +2,10 @@
 
 Converts [`minecraft:living_entity` prototype](/creators/configuration/calculations/prototypes/built-in/living-entity) into [`minecraft:entity_attribute_instance` prototype](/creators/configuration/calculations/prototypes/built-in/entity-attribute-instance) such that it represents the instance of given attribute. If the target has no attribute returns nothing.
 
+### Properties
+#### Attribute
+Property `attribute` defines an [Attribute](https://minecraft.wiki/w/Attribute). This operation will get the attribute from the living entity.
+
 # Examples
 
 The operation is used to get attribute `generic.luck` on the player and then the value of it, such that the experience source gives extra experience every time player kill entity.

--- a/skills/src/creators/configuration/calculations/operations/built-in/get-effect.md
+++ b/skills/src/creators/configuration/calculations/operations/built-in/get-effect.md
@@ -3,7 +3,10 @@
 Converts [`minecraft:living_entity` prototype](/creators/configuration/calculations/prototypes/built-in/living-entity) into [`minecraft:status_effect_instance` prototype](/creators/configuration/calculations/prototypes/built-in/status-effect-instance) such that it represents the instance of given effect. If the target has no effect returns nothing.
 
 ### Properties
-Property `effect` defines an [Effect](https://minecraft.wiki/w/Effect). This operation will return the Effect from the living entity.
+
+### Effect
+
+Property `effect` defines an [Effect](https://minecraft.wiki/w/Effect). The operation will return [`minecraft:status_effect_instance`](/creators/configuration/calculations/prototypes/built-in/status-effect-instance) of this effect from the living entity.
 
 # Examples
 

--- a/skills/src/creators/configuration/calculations/operations/built-in/get-effect.md
+++ b/skills/src/creators/configuration/calculations/operations/built-in/get-effect.md
@@ -2,6 +2,9 @@
 
 Converts [`minecraft:living_entity` prototype](/creators/configuration/calculations/prototypes/built-in/living-entity) into [`minecraft:status_effect_instance` prototype](/creators/configuration/calculations/prototypes/built-in/status-effect-instance) such that it represents the instance of given effect. If the target has no effect returns nothing.
 
+### Properties
+Property `effect` defines an [Effect](https://minecraft.wiki/w/Effect). This operation will return the Effect from the living entity.
+
 # Examples
 
 The operation is used to get effect `luck` on the player and then the level of it, such that the experience source gives extra experience every time player kill entity.

--- a/skills/src/creators/configuration/definitions.md
+++ b/skills/src/creators/configuration/definitions.md
@@ -81,7 +81,7 @@ The following definition describes a skill that after unlocking gives a player o
 |`title`|[`text`](/creators/configuration/text) object|yes|
 |`icon`|[`icon`](/creators/configuration/icons) object|yes|
 |`frame`|[`frame`](/creators/configuration/frames) object|yes|
-|`size`|float|on|
+|`size`|float|no|
 |`description`|[`text`](/creators/configuration/text) object|no|
 |`rewards`|[`rewards`](/creators/configuration/rewards/reward) array|no|
 |`cost`|integer|no|

--- a/skills/src/creators/configuration/experience-sources/built-in/break-block.md
+++ b/skills/src/creators/configuration/experience-sources/built-in/break-block.md
@@ -1,4 +1,4 @@
-# Mine Block Experience Source
+# Break Block Experience Source
 
 Experience Source `puffish_skills:break_block` gives experience when player breaks a block. It includes blocks broken with incorrect tool.
 
@@ -54,7 +54,7 @@ The following experience source gives the player exactly 5 experience every time
 ```
 :::
 ---
-This experience source will give player 1 experience if block was destroy with an Shovel.
+This experience source will give player 1 experience if block was destroyed with an iron shovel.
 ::: details Click to view
 ```json
 {

--- a/skills/src/creators/configuration/experience-sources/built-in/break-block.md
+++ b/skills/src/creators/configuration/experience-sources/built-in/break-block.md
@@ -1,6 +1,6 @@
 # Mine Block Experience Source
 
-Experience Source `puffish_skills:mine_block` gives experience when player breaks a block. It includes blocks broken with incorrect tool.
+Experience Source `puffish_skills:break_block` gives experience when player breaks a block. It includes blocks broken with incorrect tool.
 
 This [Experience Source](/creators/configuration/experience-sources/experience-source) uses [Variables](/creators/configuration/calculations/variables) and [Calculation](/creators/configuration/calculations/calculation).
 

--- a/skills/src/creators/configuration/experience-sources/built-in/break-block.md
+++ b/skills/src/creators/configuration/experience-sources/built-in/break-block.md
@@ -53,6 +53,38 @@ The following experience source gives the player exactly 5 experience every time
 }
 ```
 :::
+---
+This experience source will give player 1 experience if block was destroy with an Shovel.
+::: details Click to view
+```json
+{
+	"type": "puffish_skills:break_block",
+	"data": {
+		"variables": {
+			"is_shovel": {
+				"operations": [
+					{
+						"type": "get_tool_item_stack"
+					},
+					{
+						"type": "puffish_skills:test",
+						"data": {
+							"item": "iron_shovel"
+						}
+					}
+				]
+			}
+		},
+		"experience": [
+			{
+				"condition": "is_shovel",
+				"expression": "1"
+			}
+		]
+	}
+}
+```
+:::
 
 ## JSON Structure:
 

--- a/skills/src/creators/configuration/experience-sources/built-in/craft-item.md
+++ b/skills/src/creators/configuration/experience-sources/built-in/craft-item.md
@@ -49,7 +49,7 @@ The following experience source gives the player exactly 5 experience every time
 ```
 :::
 ---
-This experience source will give 3 experience to player when Bread is crafted.
+This experience source will give 3 experience to player when bread is crafted.
 ::: details Click to view
 ```json
 {

--- a/skills/src/creators/configuration/experience-sources/built-in/craft-item.md
+++ b/skills/src/creators/configuration/experience-sources/built-in/craft-item.md
@@ -48,3 +48,35 @@ The following experience source gives the player exactly 5 experience every time
 }
 ```
 :::
+---
+This experience source will give 3 experience to player when Bread is crafted.
+::: details Click to view
+```json
+{
+	"type": "puffish_skills:craft_item",
+	"data": {
+		"variables": {
+			"is_bread": {
+				"operations": [
+					{
+						"type": "get_crafted_item_stack"
+					},
+					{
+						"type": "puffish_skills:test",
+						"data": {
+							"item": "minecraft:bread"
+						}
+					}
+				]
+			}
+		},
+		"experience": [
+			{
+				"condition": "is_bread",
+				"expression": "3"
+			}
+		]
+	}
+}
+```
+:::

--- a/skills/src/creators/configuration/experience-sources/built-in/deal-damage.md
+++ b/skills/src/creators/configuration/experience-sources/built-in/deal-damage.md
@@ -50,3 +50,30 @@ The following experience source gives a player experience value equal to 25% of 
 }
 ```
 :::
+---
+This experience source gives player 10 experience if an entity is killed with a Diamond Sword.
+::: details Click to view
+```json
+{
+	"type": "puffish_skills:deal_damage",
+	"data": {
+		"variables": {
+			"damage": {
+				"operations": [
+					{
+						"type": "get_weapon_item_stack"
+					},
+					{
+						"type": "puffish_skills:test",
+						"data": {
+							"item": "diamond_sword"
+						}
+					}
+				]
+			}
+		},
+		"experience": "10"
+	}
+}
+```
+:::

--- a/skills/src/creators/configuration/experience-sources/built-in/deal-damage.md
+++ b/skills/src/creators/configuration/experience-sources/built-in/deal-damage.md
@@ -51,7 +51,7 @@ The following experience source gives a player experience value equal to 25% of 
 ```
 :::
 ---
-This experience source gives player 10 experience if an entity is killed with a Diamond Sword.
+This experience source gives player 10 experience if an entity is killed with a diamond sword.
 ::: details Click to view
 ```json
 {

--- a/skills/src/creators/configuration/experience-sources/built-in/fish-item.md
+++ b/skills/src/creators/configuration/experience-sources/built-in/fish-item.md
@@ -55,3 +55,35 @@ The following experience source gives the player exactly 5 experience every time
 }
 ```
 :::
+---
+This experience source gives player 1 experience if they catch a Pufferfish.
+::: details Click to view
+```json
+{
+	"type": "puffish_skills:fish_item",
+	"data": {
+		"variables": {
+			"is_pufferfish": {
+				"operations": [
+					{
+						"type": "get_fished_item_stack"
+					},
+					{
+						"type": "puffish_skills:test",
+						"data": {
+							"item": "pufferfish"
+						}
+					}
+				]
+			}
+		},
+		"experience": [
+			{
+				"condition": "is_pufferfish",
+				"expression": "1"
+			}
+		]
+	}
+}
+```
+:::

--- a/skills/src/creators/configuration/experience-sources/built-in/fish-item.md
+++ b/skills/src/creators/configuration/experience-sources/built-in/fish-item.md
@@ -56,7 +56,7 @@ The following experience source gives the player exactly 5 experience every time
 ```
 :::
 ---
-This experience source gives player 1 experience if they catch a Pufferfish.
+This experience source gives the player 1 experience when the player catches a pufferfish.
 ::: details Click to view
 ```json
 {

--- a/skills/src/creators/configuration/experience-sources/built-in/mine-block.md
+++ b/skills/src/creators/configuration/experience-sources/built-in/mine-block.md
@@ -55,15 +55,14 @@ The following experience source gives the player exactly 5 experience every time
 :::
 
 ---
-
-This experience source will give player 2 experience if block was mined with an Stone Pickaxe.
+This experience source will give player 2 experience if block was mined with a gold pickaxe.
 ::: details Click to view
 ```json
 {
 	"type": "puffish_skills:mine_block",
 	"data": {
 		"variables": {
-			"is_stone_pickaxe": {
+			"is_gold_pickaxe": {
 				"operations": [
 					{
 						"type": "get_tool_item_stack"
@@ -71,7 +70,7 @@ This experience source will give player 2 experience if block was mined with an 
 					{
 						"type": "puffish_skills:test",
 						"data": {
-							"item": "stone_pickaxe"
+							"item": "gold_pickaxe"
 						}
 					}
 				]
@@ -79,7 +78,7 @@ This experience source will give player 2 experience if block was mined with an 
 		},
 		"experience": [
 			{
-				"condition": "is_stone_pickaxe",
+				"condition": "is_gold_pickaxe",
 				"expression": "2"
 			}
 		]

--- a/skills/src/creators/configuration/experience-sources/built-in/mine-block.md
+++ b/skills/src/creators/configuration/experience-sources/built-in/mine-block.md
@@ -54,6 +54,40 @@ The following experience source gives the player exactly 5 experience every time
 ```
 :::
 
+---
+
+This experience source will give player 2 experience if block was mined with an Stone Pickaxe.
+::: details Click to view
+```json
+{
+	"type": "puffish_skills:mine_block",
+	"data": {
+		"variables": {
+			"is_stone_pickaxe": {
+				"operations": [
+					{
+						"type": "get_tool_item_stack"
+					},
+					{
+						"type": "puffish_skills:test",
+						"data": {
+							"item": "stone_pickaxe"
+						}
+					}
+				]
+			}
+		},
+		"experience": [
+			{
+				"condition": "is_stone_pickaxe",
+				"expression": "2"
+			}
+		]
+	}
+}
+```
+:::
+
 ## JSON Structure:
 
 ### `source_data` object when `type` is `mine_block`:


### PR DESCRIPTION
Its not much but its a start.

Break Block
- On site it said "mine_block" even tho it was supposed to say "break_block" now fixed.

Added Properties for:
- Effect & Attribute (get-attribute.md & get-effect.md)

Mistake in text
- In /configuration/definitons "size" after "float" required text was "on" instead of "no", now it says "no" :D